### PR TITLE
#34: first implementation of shader index files

### DIFF
--- a/src/_glsl.py
+++ b/src/_glsl.py
@@ -35,10 +35,9 @@ class FragmentShader(Shader):
     def __init__(
         self,
         out_dir : Path,
-        mesh_name : str,
-        primitive_idx : int
+        shader_name : str
     ):
-        super().__init__(out_dir, mesh_name, primitive_idx, 'frag.glsl')
+        super().__init__(out_dir, shader_name, 'frag.glsl')
 
     @staticmethod
     def _get_glslc_stage():

--- a/src/_hlsl.py
+++ b/src/_hlsl.py
@@ -62,10 +62,9 @@ class VertexShader(Shader):
     def __init__(
         self,
         out_dir : Path,
-        mesh_name : str,
-        primitive_idx : int
+        shader_name : str
     ):
-        super().__init__(out_dir, mesh_name, primitive_idx, 'VS.hlsl')
+        super().__init__(out_dir, shader_name, 'VS.hlsl')
 
     @staticmethod
     def _get_hlsl_profile():
@@ -82,10 +81,9 @@ class PixelShader(Shader):
     def __init__(
         self,
         out_dir : Path,
-        mesh_name : str,
-        primitive_idx : int
+        shader_name : str
     ):
-        super().__init__(out_dir, mesh_name, primitive_idx, 'PS.hlsl')
+        super().__init__(out_dir, shader_name, 'PS.hlsl')
 
     @staticmethod
     def _get_hlsl_profile():

--- a/src/_shader_base.py
+++ b/src/_shader_base.py
@@ -24,12 +24,11 @@ class Shader(abc.ABC):
     def __init__(
         self,
         out_dir : Path,
-        mesh_name : str,
-        primitive_idx : int,
+        shader_name : str,
         file_suffix : str
     ):
         self._file_path = (
-            out_dir / f'{mesh_name}-{primitive_idx}-{file_suffix}'
+            out_dir / f'{shader_name}-{file_suffix}'
         )
 
     @abc.abstractmethod

--- a/src/generate.py
+++ b/src/generate.py
@@ -134,8 +134,14 @@ def generate(
                 shaders += asset_result.shaders
                 shader_index[asset_result.asset_name] = asset_result.shader_index
 
-    with open(out_dir_path / 'shader_index.json', 'w') as shader_index_file:
-        json.dump(shader_index, shader_index_file)
+    shader_index_file_path = out_dir_path / 'shader_index.json'
+    with open(shader_index_file_path, 'w') as shader_index_file:
+        json.dump(
+            shader_index,
+            shader_index_file,
+            indent = 4
+        )
+    print(f'\nShader index written to {shader_index_file_path}\n')
 
     if compile:
         print()

--- a/src/generate.py
+++ b/src/generate.py
@@ -83,7 +83,7 @@ def _process_asset(
 
         per_asset_shader_index.append(per_mesh_shader_index)
         shader_index_file_path = (
-            out_dir / gltf_file_path.name().with_suffix('json')
+            out_dir / gltf_file_path.with_suffix('.json').name
         )
         with open(shader_index_file_path, 'w') as shader_index_file:
             json.dump(
@@ -91,7 +91,7 @@ def _process_asset(
                 shader_index_file,
                 indent = 4
             )
-        print(f'\nShader index written to {shader_index_file_path}\n')
+        print(f'Shader index written to {shader_index_file_path}\n')
 
     log, sys.stdout = sys.stdout, log
     return _AssetResult(


### PR DESCRIPTION
Note that:
* These files are not consumed by the host C++ code in `glTFSample` yet.
* Only one shader name is saved per primitive, which will probably change in the future to differentiate vertex/pixel stages and HLSL/HLSL for VL/GLSL.