### PR TITLE
Remove the `--compile` switch and simplify the script

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,9 +3,23 @@
     // Hover to view descriptions of existing attributes.
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
-    "configurations": [
+    "configurations": [        
         {
-            "name": "Generate",
+            "name": "Generate and compile - parallel",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/src/generate.py",
+            "console": "integratedTerminal",
+            "args": [
+                "--gltf-dir", "${workspaceFolder}/glTFSample/media/Cauldron-Media",
+                "--out-dir", "${workspaceFolder}/tests/ref/content"
+            ],
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}/metashade"
+            }
+        },
+        {
+            "name": "Generate and compile - serial",
             "type": "debugpy",
             "request": "launch",
             "program": "${workspaceFolder}/src/generate.py",
@@ -14,21 +28,6 @@
                 "--gltf-dir", "${workspaceFolder}/glTFSample/media/Cauldron-Media",
                 "--out-dir", "${workspaceFolder}/tests/ref/content",
                 "--serial"
-            ],
-            "env": {
-                "PYTHONPATH": "${workspaceFolder}/metashade"
-            }
-        },
-        {
-            "name": "Generate and compile",
-            "type": "debugpy",
-            "request": "launch",
-            "program": "${workspaceFolder}/src/generate.py",
-            "console": "integratedTerminal",
-            "args": [
-                "--gltf-dir", "${workspaceFolder}/glTFSample/media/Cauldron-Media",
-                "--out-dir", "${workspaceFolder}/tests/ref/content",
-                "--compile"
             ],
             "env": {
                 "PYTHONPATH": "${workspaceFolder}/metashade"

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -54,7 +54,6 @@ class TestGenerate:
         generate.generate(
             gltf_dir_path = gltf_dir_path,
             out_dir_path = self._out_dir,
-            compile = True,
-            serial = False,
+            serial = True,
             ref_differ = self._ref_differ
         )


### PR DESCRIPTION
1. The switch is broken anyway, because generation now happens in the "compile" stage
2. With HLSL shaders deduplicated, the whole script executes much faster, so there's not a good reason to avoid compilation.
3. Serial execution seems to be faster then parallel now.