### PR TITLE
Update imports for metashade.targets package restructuring

### DIFF
--- a/src/_glsl.py
+++ b/src/_glsl.py
@@ -15,7 +15,7 @@
 import abc, subprocess
 from pathlib import Path
 
-from metashade.glsl.util import glslang
+from metashade.targets.glsl.util import glslang
 
 import _shader_base
 import _impl.ps as impl_ps

--- a/src/_hlsl.py
+++ b/src/_hlsl.py
@@ -20,8 +20,8 @@ import _shader_base
 import _impl.ps as impl_ps
 import _impl.common as common
 
-from metashade.hlsl.util import dxc
-from metashade.glsl.util import glslang
+from metashade.targets.hlsl.util import dxc
+from metashade.targets.glsl.util import glslang
 from metashade.util.testing import RefDiffer
 from metashade.util import spirv_cross
 

--- a/src/_impl/ps.py
+++ b/src/_impl/ps.py
@@ -14,8 +14,8 @@
 
 from typing import Any, NamedTuple
 
-from metashade.hlsl.sm6 import ps_6_0
-from metashade.glsl import frag
+from metashade.targets.hlsl.sm6 import ps_6_0
+from metashade.targets.glsl import frag
 
 from . import common, _pbr_surf_lib, _uniforms
 from ._material_textures import MaterialTextures

--- a/src/_impl/vertex_data.py
+++ b/src/_impl/vertex_data.py
@@ -15,7 +15,7 @@
 from collections import OrderedDict
 from typing import NamedTuple
 
-from metashade.hlsl.sm6 import vs_6_0
+from metashade.targets.hlsl.sm6 import vs_6_0
 from . import common, _uniforms
 
 class VertexData:

--- a/src/generate.py
+++ b/src/generate.py
@@ -19,8 +19,8 @@ from typing import List, NamedTuple
 from pygltflib import GLTF2
 
 from metashade.util import perf
-from metashade.hlsl.util import dxc
-from metashade.glsl.util import glslang
+from metashade.targets.hlsl.util import dxc
+from metashade.targets.glsl.util import glslang
 from metashade.util.testing import RefDiffer
 
 import _shader_base, _hlsl, _glsl


### PR DESCRIPTION
The metashade submodule PR #179 moved target packages (hlsl, glsl) under `metashade.targets`. Updated all imports accordingly:

- `metashade.hlsl.*` → `metashade.targets.hlsl.*`
- `metashade.glsl.*` → `metashade.targets.glsl.*`

## Files Updated
- `src/generate.py`
- `src/_glsl.py`
- `src/_hlsl.py`
- `src/_impl/ps.py`
- `src/_impl/vertex_data.py`
- `metashade` submodule pointer

## Testing
- `tests/test_generate.py` passes ✅